### PR TITLE
Improvements to bind method

### DIFF
--- a/dist/webview.js
+++ b/dist/webview.js
@@ -181,7 +181,9 @@ class Webview {
                 return [0, result];
             }
             catch (error) {
-                return [1, JSON.stringify(error)];
+                // JSON.stringify(error) returns "[object Object]", call String to get message
+                // need JSON.stringify to wrap string in quotes
+                return [1, JSON.stringify(String(error))];
             }
         });
     }

--- a/dist/webview.js
+++ b/dist/webview.js
@@ -169,9 +169,16 @@ class Webview {
     */
     bind(name, fn) {
         this.bindRaw(name, (w, req) => {
+            var _a;
             let args = JSON.parse(req);
             try {
-                return [0, JSON.stringify(fn(w, ...args))];
+                const resultValue = (_a = fn(w, ...args)) !== null && _a !== void 0 ? _a : null; // convert undefined to null
+                const result = JSON.stringify(resultValue);
+                if (result === undefined) {
+                    // need JSON.stringify to wrap string in quotes
+                    return [1, JSON.stringify(`JSON.stringify failed for return value ${resultValue}`)];
+                }
+                return [0, result];
             }
             catch (error) {
                 return [1, JSON.stringify(error)];

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -196,8 +196,17 @@ export class Webview {
         this.bindRaw(name, (w: any,req: string)=>{
             let args :any[] = JSON.parse(req);
             try {
-                return [0,  JSON.stringify(fn(w,...args))];
-            } catch(error) {
+                const resultValue = fn(w, ...args) ?? null; // convert undefined to null
+                const result = JSON.stringify(resultValue);
+
+                if (result === undefined) {
+                    // need JSON.stringify to wrap string in quotes
+                    return [1, JSON.stringify(`JSON.stringify failed for return value ${resultValue}`)];
+                }
+
+                return [0, result];
+            }
+            catch (error) {
                 return [1, JSON.stringify(error)]
             }
         });

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -207,7 +207,9 @@ export class Webview {
                 return [0, result];
             }
             catch (error) {
-                return [1, JSON.stringify(error)]
+                // JSON.stringify(error) returns "[object Object]", call String to get message
+                // need JSON.stringify to wrap string in quotes
+                return [1, JSON.stringify(String(error))];
             }
         });
     }


### PR DESCRIPTION
- Allows passing handlers to bind without explicit return values (otherwise `JSON.stringify` fails on implicit `undefined`)
- Reports instances where `JSON.stringify` cannot serialize a return value
- Converts errors to meaningful strings, rather than "[object Object]"