### PR TITLE
Patch to fix minor C++ and Linux issues

### DIFF
--- a/libwebview-nodejs/package-lock.json
+++ b/libwebview-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "libwebview-nodejs",
-  "version": "0.1.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "libwebview-nodejs",
-      "version": "0.1.0",
+      "version": "0.12.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/libwebview-nodejs/package.json
+++ b/libwebview-nodejs/package.json
@@ -8,10 +8,10 @@
     "CMakeLists.txt"
   ],
   "scripts": {
-    "install": "cmake-js rebuild",
+    "install": "cmake-js rebuild --CDWEBVIEW_WEBKITGTK_API=\"$WEBVIEW_WEBKITGTK_API\"",
     "start": "node test.js",
-    "build": "cmake-js build",
-    "rebuild": "cmake-js rebuild",
+    "build": "cmake-js build --CDWEBVIEW_WEBKITGTK_API=\"$WEBVIEW_WEBKITGTK_API\"",
+    "rebuild": "cmake-js rebuild --CDWEBVIEW_WEBKITGTK_API=\"$WEBVIEW_WEBKITGTK_API\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/libwebview-nodejs/src/webview_wrap.cxx
+++ b/libwebview-nodejs/src/webview_wrap.cxx
@@ -1974,6 +1974,7 @@ Napi::Value _wrap_webview_bind(const Napi::CallbackInfo &info) {
   char *buf2 = 0 ;
   int alloc2 = 0 ;
   int res4 ;
+  BindArg* cb;
   
   if(static_cast<int>(info.Length()) < 4 || static_cast<int>(info.Length()) > 4) {
     SWIG_Error(SWIG_ERROR, "Illegal number of arguments for _wrap_webview_bind.");
@@ -2005,7 +2006,7 @@ Napi::Value _wrap_webview_bind(const Napi::CallbackInfo &info) {
     int res = SWIG_ConvertFunctionPtr(info[2], (void**)(&arg3), SWIGTYPE_p_f_p_q_const__char_p_q_const__char_p_void__void);
     SWIG_exception_fail(SWIG_ArgError(res), "in method '" "webview_bind" "', argument " "3"" of type '" "void (*)(char const *,char const *,void *)""'"); 
   }
-  BindArg* cb = new BindArg {
+  cb = new BindArg {
     Napi::FunctionReference(Napi::Persistent(info[2].As<Napi::Function>())),
     env
   };


### PR DESCRIPTION
The basic idea of this PR is just to fix a couple issues that arise due to using newer versions of Webview.

The first thing is to allow passing `WEBVIEW_WEBKITGTK_API` to webview so that you can specify your WebKit version for building for Linux (see: 'https://github.com/webview/webview#linux-specific-options'). The big usecase for this is that by default `webview` will be built against `webkit2gtk4.0` which doesn't exist in the Fedora Linux repos anymore (and version `4.1` is the recommended version now anyway) so the build will break. You can now install this package with the environment var `WEBVIEW_WEBKITGTK_API` which gets passed to CMake and then you can specify the version you want installed, e.g.
```sh
WEBVIEW_WEBKITGTK_API="6.0" npm install webview-nodejs
```
I am completely welcome to different ways we could fix this, this was just the only thing I could think of besides incrementing the webview version manually in the `package.json`.

This PR also fixes a minor issue with newer C++ versions that breaks build due to a var being initialised before the 'exit' label in `webview_wrap.cxx` .

EDIT: fixed some grammar